### PR TITLE
Resolve case mismatches inside shipped .vmt material content

### DIFF
--- a/mod/process.sh
+++ b/mod/process.sh
@@ -1,3 +1,76 @@
+resolve_case_component() {
+    local parent="$1"
+    local want="$2"
+    local entry base
+
+    if [[ -e "$parent/$want" ]]; then
+        printf '%s' "$want"
+        return 0
+    fi
+
+    for entry in "$parent"/*; do
+        [[ -e "$entry" ]] || continue
+        base="${entry##*/}"
+        if [[ "${base,,}" == "${want,,}" ]]; then
+            if ln -s "$base" "$parent/$want" 2>/dev/null; then
+                echo "$parent/$want" >> "$path_undo/undo.dat"
+                echo "Case-fix symlink: '$parent/$want' -> '$base'" >&2
+            fi
+            printf '%s' "$want"
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+resolve_material_case_ref() {
+    local root="$1"
+    local relpath="$2"
+    local cur="$root"
+    local part resolved
+    local -a parts
+
+    IFS='/' read -ra parts <<< "$relpath"
+    for part in "${parts[@]}"; do
+        [[ -z "$part" ]] && continue
+        resolved=$(resolve_case_component "$cur" "$part") || return 1
+        cur="$cur/$resolved"
+    done
+
+    return 0
+}
+
+resolve_material_case_refs() {
+    local job_tmp="$1"
+    local bsp_base="$2"
+    local vmt_root="$job_tmp/$bsp_base/materials"
+    local mat_dest="$path_sync/materials"
+    local vmt line key val
+
+    [[ -d "$vmt_root" && -d "$mat_dest" ]] || return 0
+
+    while IFS= read -r -d '' vmt; do
+        while IFS= read -r line; do
+            [[ "$line" =~ \"(\$[A-Za-z0-9_]+|include)\"[[:space:]]*\"([^\"]+)\" ]] || continue
+            key="${BASH_REMATCH[1]}"
+            val="${BASH_REMATCH[2]//\\//}"
+
+            if [[ "${key,,}" == "include" ]]; then
+                val="${val#materials/}"
+                val="${val#/}"
+            else
+                [[ "$val" == */* ]] || continue
+                val="${val}.vtf"
+            fi
+
+            resolve_material_case_ref "$mat_dest" "$val"
+        done < "$vmt"
+    done < <(find "$vmt_root" -type f -iname "*.vmt" -print0)
+
+    return 0
+}
+
 process_bsp() {
     local bsp="$1"
     local is_parallel="${2:-0}"
@@ -54,6 +127,8 @@ process_bsp() {
                 return 1
         fi
         echo "Successfully synchronized data for '$bsp_name' ($hash)" >&2
+
+        resolve_material_case_refs "$job_tmp" "$bsp_base"
     else
         echo "No relevant directories to sync for '$bsp_name' ($hash)" >&2
     fi
@@ -94,6 +169,9 @@ process_parallel() {
     export skip_processed
 
     export -f process_bsp
+    export -f resolve_material_case_refs
+    export -f resolve_material_case_ref
+    export -f resolve_case_component
     export -f rm_dir
     export -f rm_file
     export -f hash_check


### PR DESCRIPTION
Fixes #18

## What changed

Adds a post-sync step to `process_bsp()` (`mod/process.sh`) that scans every freshly-extracted `.vmt` for a BSP and symlinks case-mismatched references it finds inside the file *content* — not just the pak-lump filenames lbspcfw already handles.

Three new functions:

- `resolve_case_component(parent, want)` — if `parent/want` doesn't exist exactly, case-insensitively finds the real entry in `parent/` and symlinks the wanted case to it. Only creates a symlink when no exact match exists; never touches/overwrites real files. Logs every created symlink to `$path_undo/undo.dat`.
- `resolve_material_case_ref(root, relpath)` — walks a relative path component-by-component through the above, so a fix can land at directory level (`DEVNEONS -> devneons`) or file level (`PK02_FLOOR13A.vmt -> pk02_floor13a.vmt`) depending on where the mismatch actually is.
- `resolve_material_case_refs(job_tmp, bsp_base)` — scans the BSP's extracted `.vmt` files for two reference styles and calls the above on each:
  - `"include" "materials/PACK/FILE.vmt"` (auto-generated per-brush "patch" materials — see why this matters below)
  - `$basetexture`, `$bumpmap`, `$detail`, `$envmapmask`, `$normalmap`, `$blendmodulatetexture`, `$texture2`

Hooked in right after the existing rsync succeeds, and exported alongside the other functions so it works under the GNU `parallel` bulk-processing path too.

## Why this shape

**Why scan `.vmt` content instead of just filenames:** the existing pipeline already gets filename case right, by construction — it syncs files using whatever case the BSP's pak lump says. The bug here is different: a map's own `.vmt` can reference *another* shipped asset by name, in text, using different case than that asset's real filename. That text was authored/tested on Windows (case-insensitive), so it was never caught there. lbspcfw's existing scope doesn't touch this because it isn't a pak-lump-entry-naming problem, but the failure mode (checkerboard texture) and root cause (case-insensitive-on-Windows-only content) are identical to what this tool already exists to fix — it's just one layer deeper.

**Why `"include"` gets separate handling:** it's structurally different from a texture key. `$basetexture` values are implicitly relative to `materials/` and never carry that prefix; `"include"` values are also materials-root-relative but *do* usually carry a literal `materials/` prefix, and point at another `.vmt` rather than a `.vtf`. Auto-generated per-brush "patch" materials (one per env_cubemap-affected brush face, named `<file>_<x>_<y>_<z>.vmt`) use `"include"` exclusively to reach their base material, and nearly every reflective surface on a map goes through one of these. A single uppercase `include` path (`DEVNEONS/PINK_NEON.vmt` vs. real `devneons/pink_neon.vmt`) was enough to checkerboard entire rooms in testing — this is the dominant real-world cause, not a hypothetical.

**Why component-by-component resolution instead of one exact-string lookup:** the same map showed both directory-wide mismatches (`DEVNEONS` vs `devneons`, every file under it) and single-file mismatches within an otherwise-correct lowercase directory (`pk02/PK02_FLOOR13A.vmt` vs `pk02/pk02_floor13a.vmt`). Walking the path and fixing whichever component(s) actually differ handles both without needing to know in advance which shape a given mismatch takes.

**Why symlinks, not rewriting `.vmt` text:** editing shipped map content felt like the obvious fix at one point during investigation and turned out to be wrong — the original references are correct as authored (they work as-is on Windows), so rewriting them is fixing the wrong layer and would fight the BSP's actual shipped content on every reprocess. A symlink makes the exact string the file asks for resolve, without touching what the file says.

**Why log to `undo.dat` instead of a new tracking file:** `undo_sync()` (`mod/system.sh`) already reads `$path_undo/undo.dat` line-by-line and matches on `/(materials|models|sound)/` to support `--undo`/`--reset`/`--purge`. Appending symlink paths in the same format means cleanup keeps working with zero changes to that code.

**Why no new CLI flag:** this is the same class of bug the tool already fixes unconditionally (pak-lump filename casing) — gating the content-level fix behind a flag would leave users needing to know to opt in to something that's really just "the rest of the existing fix."

## Explicitly out of scope

A separate, unrelated bug was found during the same investigation: CS:S's Linux client silently drops a single-letter path directory component (`R/ceiling` logs as `couldn't find materials//ceiling.vtf`, note the empty component) before the filesystem is ever touched. No case variant of `R`/`r` resolves it, and the reference is correct on Windows as shipped — it's an engine bug, not a case-folding one, and out of scope here. Left undocumented for now; happy to add a README callout if useful.

## Testing

Verified against an isolated fixture (not the live game folder) reproducing all three reference shapes found in the wild (`include`-style uppercase patch path, `$basetexture` mixed-case, single-letter-dir `$envmapmask`):

- All three resolve to the correct symlinks on first run.
- Second run is fully idempotent — no duplicate work, no errors, no re-created symlinks.
- `undo.dat` receives one line per created symlink in the existing format.
- Confirmed `bash -n` passes on all changed/existing files.

The exact symlink set the new code produces was cross-checked against the set built by hand while debugging `surf_eternity.bsp` live and matches.
